### PR TITLE
Refactor script URL handling for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gacha Tracker
 
-This is the Repository for all PowerShell Files to copy your Gacha Links. Now with support for Multiple Languages. 
+This is the Repository for all PowerShell Files to copy your Gacha Links. Now with support for Multiple Languages.
 
 To add your own language, please fork this repository, update the `language.json` file and add your language translation in the `i18n` folder
 
@@ -11,6 +11,7 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManage
 ```
 
 Cloudflare - Interactive Menu:
+
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://gacha.studiobutter.io.vn/start.ps1?ref_type=heads'))}"
 ```
@@ -22,3 +23,11 @@ Credits:
 [Star Rail Station](https://starrailstation.com/en)
 
 [zzz.rng.moe](https://zzz.rng.moe/en)
+
+## Developing Locally
+
+```powershell
+$env:GACHA_LOCAL_TEST = "true"
+$env:GACHA_LOCAL_PATH = "C:\path\to\your\local\repo"
+.\start.ps1
+```

--- a/gacha_menu/hk4e-gacha.ps1
+++ b/gacha_menu/hk4e-gacha.ps1
@@ -2,6 +2,20 @@ $gachaLogTmp = "$env:TMP\gacha-log"
 Import-LocalizedData -BaseDirectory $gachaLogTmp -FileName 'Gacha.Resources.psd1' -BindingVariable Locale
 
 Clear-Host
+
+function Get-ScriptUrl {
+    param([string]$ScriptPath)
+    
+    $isLocalTesting = $env:GACHA_LOCAL_TEST -eq "true"
+    if ($isLocalTesting) {
+        $localPath = Join-Path $env:GACHA_LOCAL_PATH $ScriptPath
+        return "file:///$($localPath.Replace('\', '/'))"
+    }
+    else {
+        return "https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/$ScriptPath"
+    }
+}
+
 function Show-Menu {
     Write-Host $Locale.GachaMenuChooseLink
     foreach ($option in $Locale.RegionOptions) {
@@ -10,14 +24,14 @@ function Show-Menu {
 }
 
 function Get-Gacha_os {
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/getlink.ps1'))} global"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "gacha_clipboard/getlink.ps1")))} global"
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
 }
 
 function Get-Gacha_cn {
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/getlink.ps1'))} china"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "gacha_clipboard/getlink.ps1")))} china"
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
@@ -25,7 +39,7 @@ function Get-Gacha_cn {
 }
 
 function Get-Gacha_Cloud {
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/gacha_cloud_hk4e.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "gacha_clipboard/gacha_cloud_hk4e.ps1")))}"
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
@@ -33,7 +47,7 @@ function Get-Gacha_Cloud {
 
 function Close-Clear {
     Write-Host $Locale.GachaMenuExit -ForegroundColor Yellow
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/cleanup.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "cleanup.ps1")))}"
     exit 0
 }
 

--- a/gacha_menu/hkrpg-gacha.ps1
+++ b/gacha_menu/hkrpg-gacha.ps1
@@ -2,6 +2,20 @@ $gachaLogTmp = "$env:TMP\gacha-log"
 Import-LocalizedData -BaseDirectory $gachaLogTmp -FileName 'Gacha.Resources.psd1' -BindingVariable Locale
 
 Clear-Host
+
+function Get-ScriptUrl {
+    param([string]$ScriptPath)
+    
+    $isLocalTesting = $env:GACHA_LOCAL_TEST -eq "true"
+    if ($isLocalTesting) {
+        $localPath = Join-Path $env:GACHA_LOCAL_PATH $ScriptPath
+        return "file:///$($localPath.Replace('\', '/'))"
+    }
+    else {
+        return "https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/$ScriptPath"
+    }
+}
+
 function Show-Menu {
     Write-Host $Locale.GachaMenuChooseLink
     foreach ($option in $Locale.RegionOptionsNoCloud) {
@@ -10,14 +24,14 @@ function Show-Menu {
 }
 
 function Get-Gacha_os {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/get_warp_link_os.ps1?cachebust=srs")
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("$(Get-ScriptUrl "gacha_clipboard/get_warp_link_os.ps1")?cachebust=srs")
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
 }
 
 function Get-Gacha_cn {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/get_warp_link_cn.ps1?cachebust=srs")
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("$(Get-ScriptUrl "gacha_clipboard/get_warp_link_cn.ps1")?cachebust=srs")
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
@@ -25,7 +39,7 @@ function Get-Gacha_cn {
 
 function Close-Clear {
     Write-Host $Locale.GachaMenuExit -ForegroundColor Yellow
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/cleanup.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "cleanup.ps1")))}"
     exit 0
 }
 

--- a/gacha_menu/nap-gacha.ps1
+++ b/gacha_menu/nap-gacha.ps1
@@ -2,6 +2,20 @@ $gachaLogTmp = "$env:TMP\gacha-log"
 Import-LocalizedData -BaseDirectory $gachaLogTmp -FileName 'Gacha.Resources.psd1' -BindingVariable Locale
 
 Clear-Host
+
+function Get-ScriptUrl {
+    param([string]$ScriptPath)
+    
+    $isLocalTesting = $env:GACHA_LOCAL_TEST -eq "true"
+    if ($isLocalTesting) {
+        $localPath = Join-Path $env:GACHA_LOCAL_PATH $ScriptPath
+        return "file:///$($localPath.Replace('\', '/'))"
+    }
+    else {
+        return "https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/$ScriptPath"
+    }
+}
+
 function Show-Menu {
     Write-Host $Locale.GachaMenuChooseLink
     foreach ($option in $Locale.RegionOptions) {
@@ -10,21 +24,21 @@ function Show-Menu {
 }
 
 function Get-Gacha_os {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/get_signal_link_os.ps1")
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("$(Get-ScriptUrl 'gacha_clipboard/get_signal_link_os.ps1')")
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
 }
 
 function Get-Gacha_cn {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/get_signal_link_cn.ps1")
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("$(Get-ScriptUrl 'gacha_clipboard/get_signal_link_cn.ps1')")
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
 }
 
 function Get-Gacha_Cloud {
-    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_clipboard/gacha_cloud_nap.ps1")
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; Invoke-Expression (New-Object Net.WebClient).DownloadString("$(Get-ScriptUrl 'gacha_clipboard/gacha_cloud_nap.ps1')")
     Write-Host $Locale.TaskCompleted
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
     Close-Clear
@@ -32,7 +46,7 @@ function Get-Gacha_Cloud {
 
 function Close-Clear {
     Write-Host $Locale.GachaMenuExit -ForegroundColor Yellow
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/cleanup.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "cleanup.ps1")))}"
     exit 0
 }
 

--- a/menu.ps1
+++ b/menu.ps1
@@ -4,6 +4,20 @@ Import-LocalizedData -BaseDirectory $gachaLogTmp -FileName 'Gacha.Resources.psd1
 
 Clear-Host
 [Console]::Title = $Locale.GachaMenuTitle
+
+function Get-ScriptUrl {
+    param([string]$ScriptPath)
+    
+    $isLocalTesting = $env:GACHA_LOCAL_TEST -eq "true"
+    if ($isLocalTesting) {
+        $localPath = Join-Path $env:GACHA_LOCAL_PATH $ScriptPath
+        return "file:///$($localPath.Replace('\', '/'))"
+    }
+    else {
+        return "https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/$ScriptPath"
+    }
+}
+    
 function Show-Menu {
     Write-Host $Locale.GachaMenuDescription
     foreach ($option in $Locale.GachaMenuOptions) {
@@ -12,20 +26,20 @@ function Show-Menu {
 }
 
 function Get-Gacha_hk4e {
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_menu/hk4e-gacha.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "gacha_menu/hk4e-gacha.ps1")))}"
 }
 
 function Get-Gacha_hkrpg {
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_menu/hkrpg-gacha.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "gacha_menu/hkrpg-gacha.ps1")))}"
 }
 
 function Get-Gacha_nap {
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/gacha_menu/nap-gacha.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "gacha_menu/nap-gacha.ps1")))}"
 }
 
 function Close-Clear {
     Write-Host $Locale.GachaMenuExit -ForegroundColor Yellow
-    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/cleanup.ps1'))}"
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "cleanup.ps1")))}"
     exit 0
 }
 

--- a/saveReg.ps1
+++ b/saveReg.ps1
@@ -1,10 +1,24 @@
+function Get-ScriptUrl {
+    param([string]$ScriptPath)
+    
+    $isLocalTesting = $env:GACHA_LOCAL_TEST -eq "true"
+    if ($isLocalTesting) {
+        $localPath = Join-Path $env:GACHA_LOCAL_PATH $ScriptPath
+        return "file:///$($localPath.Replace('\', '/'))"
+    }
+    else {
+        return "https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/$ScriptPath"
+    }
+}
+
 # Check for Administrator rights
 if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
     Write-Output "Script is not running as Administrator. Attempting to relaunch with elevated privileges..."
     $pwshPath = (Get-Command pwsh.exe -ErrorAction SilentlyContinue)?.Source
     if ($pwshPath) {
         Start-Process $pwshPath "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" $args" -Verb RunAs
-    } else {
+    }
+    else {
         Start-Process powershell "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" $args" -Verb RunAs
     }
     exit
@@ -31,11 +45,13 @@ if ($args.Count -gt 0) {
         Set-ItemProperty -Path $regPath -Name 'lang' -Value $inputText
         Write-Output $Locale.RegRememberSuccess
 
-    } else {
+    }
+    else {
         Write-Output $Locale.RegRememberCancelled
     }
-} else {
+}
+else {
     Write-Output "No text provided. Usage: ./saveReg.ps1 [text]"
 }
 
-Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/Copy-Menu.ps1'))}"
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "&{$((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "Copy-Menu.ps1")))}"

--- a/start.ps1
+++ b/start.ps1
@@ -1,6 +1,19 @@
 Clear-Host
 [Console]::Title = "Gacha Clipboard Catcher"
 
+function Get-ScriptUrl {
+    param([string]$ScriptPath)
+    
+    $isLocalTesting = $env:GACHA_LOCAL_TEST -eq "true"
+    if ($isLocalTesting) {
+        $localPath = Join-Path $env:GACHA_LOCAL_PATH $ScriptPath
+        return "file:///$($localPath.Replace('\', '/'))"
+    }
+    else {
+        return "https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/$ScriptPath"
+    }
+}
+
 $systemLanguage = Get-Culture
 Write-Host "User TEMP folder: $env:TMP"
 
@@ -21,7 +34,8 @@ $regLang = $null
 if (Test-Path $regPath) {
     try {
         $regLang = (Get-ItemProperty -Path $regPath -Name 'lang' -ErrorAction SilentlyContinue).lang
-    } catch {}
+    }
+    catch {}
 }
 
 if ($regLang) {
@@ -40,21 +54,24 @@ if ($regLang) {
         if (Test-Path $resourceFile) {
             Import-LocalizedData -BaseDirectory $gachaLogTmp -FileName 'Gacha.Resources.psd1' -BindingVariable Locale
             Write-Host "Loaded language resource file for '$commonCode'." -ForegroundColor Cyan
-        } else {
+        }
+        else {
             Write-Host "Resource file not found after download." -ForegroundColor Yellow
         }
-    } catch {
+    }
+    catch {
         Write-Host "Failed to download Gacha.Resources.psd1 for '$commonCode': $_" -ForegroundColor Red
     }
-        if (Test-Path $resourceFile) {
-            $GachaResources = Import-PowerShellDataFile -Path $resourceFile
-            Write-Output $GachaResources.Greeting
-            Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "& { $((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/studiobutter/gacha-stuff/refs/heads/main/menu.ps1')) }"
-        } else {
-            Write-Host "Resource file not found, cannot display greeting." -ForegroundColor Yellow
-        }
-        return
+    if (Test-Path $resourceFile) {
+        $GachaResources = Import-PowerShellDataFile -Path $resourceFile
+        Write-Output $GachaResources.Greeting
+        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex "& { $((New-Object System.Net.WebClient).DownloadString($(Get-ScriptUrl "menu.ps1"))) }"
     }
+    else {
+        Write-Host "Resource file not found, cannot display greeting." -ForegroundColor Yellow
+    }
+    return
+}
 # Download language.json from repo to $env:TMP/gacha-log
 $gachaLogTmp = Join-Path $env:TMP 'gacha-log'
 if (-not (Test-Path $gachaLogTmp)) {
@@ -108,35 +125,41 @@ if ($useSystemLang) {
     if ($foundLang) {
         $commonCode = $foundLang.commonCode
         Write-Host "Using System Language: $($systemLanguage.Name) ($commonCode)"
-    } else {
+    }
+    else {
         # Fallback to English
         $englishLang = $languages | Where-Object { $_.commonCode -eq 'en' }
         if ($englishLang) {
             $commonCode = $englishLang.commonCode
             Write-Host "System Language '$($systemLanguage.Name)' not available, falling back to English ($commonCode)" -ForegroundColor Yellow
-        } else {
+        }
+        else {
             Write-Host "System Language and English fallback not found in language.json!" -ForegroundColor Red
             exit 1
         }
     }
-} else {
+}
+else {
     $selectedLanguage = $languages[$selectedIndex - 1]
     $commonCode = $selectedLanguage.commonCode
     Write-Host "Selected language: $($selectedLanguage.name) ($commonCode)"
 }
 
 if ($commonCode -in @(
-    'en-us', 'en-gb', 'en-au', 'en-ca', 'en-nz', 'en-ie', 'en-za', 'en-in', 'en-sg'
-)) {
+        'en-us', 'en-gb', 'en-au', 'en-ca', 'en-nz', 'en-ie', 'en-za', 'en-in', 'en-sg'
+    )) {
     $commonCode = 'en'
     $env:GACHA_LANG = $commonCode
-} elseif ($commonCode -in @('zh-tw', 'zh-hk')) {
+}
+elseif ($commonCode -in @('zh-tw', 'zh-hk')) {
     $commonCode = 'zh-tw'
     $env:GACHA_LANG = $commonCode
-} elseif ($commonCode -eq 'vi-vn') {
+}
+elseif ($commonCode -eq 'vi-vn') {
     $commonCode = 'vi'
     $env:GACHA_LANG = $commonCode
-} else {
+}
+else {
     $env:GACHA_LANG = $commonCode
 }
 
@@ -151,10 +174,12 @@ try {
     if (Test-Path $resourceFile) {
         $GachaResources = Import-PowerShellDataFile -Path $resourceFile
         Write-Host "Loaded language resource file for '$commonCode'." -ForegroundColor Cyan
-    } else {
+    }
+    else {
         Write-Host "Resource file not found after download." -ForegroundColor Yellow
     }
-} catch {
+}
+catch {
     Write-Host "Failed to download Gacha.Resources.psd1 for '$commonCode': $_" -ForegroundColor Red
 }
 
@@ -165,6 +190,7 @@ try {
     Invoke-WebRequest -Uri $saveRegUrl -OutFile $saveRegFile -UseBasicParsing
     Write-Host "Downloaded saveReg.ps1 to $saveRegFile" -ForegroundColor Green
     & $saveRegFile $commonCode
-} catch {
+}
+catch {
     Write-Host "Failed to download or run saveReg.ps1: $_" -ForegroundColor Red
 }


### PR DESCRIPTION
Add a `Get-ScriptUrl` function to each script that uses `DownloadString`, which outputs a different URL (local disk path or http) based on env vars. This enables local testing.